### PR TITLE
Allow specifying the google-java-format version for the "removeUnusedImports" task

### DIFF
--- a/lib/src/main/java/com/github/autostyle/java/RemoveUnusedImportsStep.java
+++ b/lib/src/main/java/com/github/autostyle/java/RemoveUnusedImportsStep.java
@@ -28,9 +28,13 @@ public class RemoveUnusedImportsStep {
   static final String NAME = "removeUnusedImports";
 
   public static FormatterStep create(Provisioner provisioner) {
+    return create(provisioner, GoogleJavaFormatStep.defaultVersion());
+  }
+
+  public static FormatterStep create(Provisioner provisioner, String version) {
     Objects.requireNonNull(provisioner, "provisioner");
     return FormatterStep.createLazy(NAME,
-        () -> new GoogleJavaFormatStep.State(NAME, GoogleJavaFormatStep.defaultVersion(), provisioner),
+        () -> new GoogleJavaFormatStep.State(NAME, version, provisioner),
         GoogleJavaFormatStep.State::createRemoveUnusedImportsOnly);
   }
 }

--- a/plugin-gradle/src/main/kotlin/com/github/autostyle/gradle/JavaExtension.kt
+++ b/plugin-gradle/src/main/kotlin/com/github/autostyle/gradle/JavaExtension.kt
@@ -42,9 +42,16 @@ open class JavaExtension @Inject constructor(name: String, root: AutostyleExtens
         addStep(ImportOrderStep.forJava().createFrom(*importOrder))
     }
 
-    /** Removes any unused imports.  */
-    fun removeUnusedImports() {
-        addStep(RemoveUnusedImportsStep.create(project.asProvisioner()))
+    /**
+     * Uses the given version of [google-java-format](https://github.com/google/google-java-format) to remove unused imports.
+     *
+     * Limited to published versions.  See [issue #33](https://github.com/diffplug/spotless/issues/33#issuecomment-252315095)
+     * for an workaround for using snapshot versions.
+     */
+    /** Removes any unused imports.*/
+    @JvmOverloads
+    fun removeUnusedImports(version: String = GoogleJavaFormatStep.defaultVersion()) {
+        addStep(RemoveUnusedImportsStep.create(project.asProvisioner(), version))
     }
 
     fun googleJavaFormat(action: Action<GoogleJavaFormatConfig>) {


### PR DESCRIPTION
As described in #23 using always the same version for google-java-format has undesirable side effects when using autostyle with newer java versions.

Some things to consider:
- Currently a new parameter `version` is added to the `#removeUnusedImports()` function. For api compatibility it is annotated with `@JvmOverloads` . This will also provide ABI compatibility for Java consumers of the class. However adding a new parameter to the function will break ABI compatibility with kotlin code. If this is an issue I will create a new functions instead and annotated the old one with `Deprecated(level = HIDDEN)`.
- Would it be feasible to update the default version of google-java-format?