### PR TITLE
fix: restore CI broken by junit-bom 5.13 and google-java-format 1.28

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,6 +85,10 @@ allprojects {
             testImplementation("org.junit.jupiter:junit-jupiter-params")
             testImplementation("org.hamcrest:hamcrest")
             testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+            // Gradle bundles an older junit-platform-launcher; declare it so the launcher
+            // aligns with the junit-bom (5.13.x / platform 1.13.x), otherwise test discovery
+            // fails with "OutputDirectoryProvider not available".
+            testRuntimeOnly("org.junit.platform:junit-platform-launcher")
         }
     }
 
@@ -145,6 +149,15 @@ allprojects {
             }
             withType<Test>().configureEach {
                 useJUnitPlatform()
+                // google-java-format 1.28 reaches into jdk.compiler internals; tests that
+                // run the formatter need these exports on JDK 16+.
+                jvmArgs(
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                    "--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+                )
                 testLogging {
                     exceptionFormat = TestExceptionFormat.FULL
                     showStandardStreams = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 import com.github.vlsi.gradle.properties.dsl.props
+import java.time.Duration
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-import java.time.Duration
 
 plugins {
     id("com.github.autostyle")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,8 @@
 # Gradle
 org.gradle.parallel=true
+# google-java-format 1.28 reaches into jdk.compiler internals. The self-check runs the
+# formatter inside the build JVM, so the daemon needs these exports on JDK 16+.
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 kotlin.code.style=official
 
 org=autostyle

--- a/lib-extra/src/main/kotlin/com/github/autostyle/extra/integration/WriteSpaceAwareDiffFormatter.kt
+++ b/lib-extra/src/main/kotlin/com/github/autostyle/extra/integration/WriteSpaceAwareDiffFormatter.kt
@@ -49,10 +49,10 @@ internal class WriteSpaceAwareDiffFormatter(
         private val CR_UTF8 = CR.toByteArray(StandardCharsets.UTF_8)
         private val LF_UTF8 = LF.toByteArray(StandardCharsets.UTF_8)
         private val TAB_UTF8 = TAB.toByteArray(StandardCharsets.UTF_8)
-        private val SPACE_SIMPLE = byteArrayOf(' '.toByte())
-        private val CR_SIMPLE = byteArrayOf('\\'.toByte(), 'r'.toByte())
-        private val LF_SIMPLE = byteArrayOf('\\'.toByte(), 'n'.toByte())
-        private val TAB_SIMPLE = byteArrayOf('\\'.toByte(), 't'.toByte())
+        private val SPACE_SIMPLE = byteArrayOf(' '.code.toByte())
+        private val CR_SIMPLE = byteArrayOf('\\'.code.toByte(), 'r'.code.toByte())
+        private val LF_SIMPLE = byteArrayOf('\\'.code.toByte(), 'n'.code.toByte())
+        private val TAB_SIMPLE = byteArrayOf('\\'.code.toByte(), 't'.code.toByte())
         private val isWindows = "win" in System.getProperty("os.name").toLowerCase()
         private fun replacementFor(
             charsetEncoder: CharsetEncoder,
@@ -96,7 +96,7 @@ internal class WriteSpaceAwareDiffFormatter(
             if (firstLine) {
                 firstLine = false
             } else {
-                out.write('\n'.toInt())
+                out.write('\n'.code)
             }
             header(lineA, endA, lineB, endB)
             var showWhitespace = edit.type == Edit.Type.REPLACE
@@ -153,26 +153,26 @@ internal class WriteSpaceAwareDiffFormatter(
     }
 
     private fun header(lineA: Int, endA: Int, lineB: Int, endB: Int) {
-        out.write('@'.toInt())
-        out.write('@'.toInt())
+        out.write('@'.code)
+        out.write('@'.code)
         range('-', lineA + 1, endA - lineA)
         range('+', lineB + 1, endB - lineB)
-        out.write(' '.toInt())
-        out.write('@'.toInt())
-        out.write('@'.toInt())
+        out.write(' '.code)
+        out.write('@'.code)
+        out.write('@'.code)
     }
 
     private fun range(prefix: Char, begin: Int, length: Int) {
-        out.write(' '.toInt())
-        out.write(prefix.toInt())
+        out.write(' '.code)
+        out.write(prefix.code)
         if (length == 0) {
             writeInt(begin - 1)
-            out.write(','.toInt())
-            out.write('0'.toInt())
+            out.write(','.code)
+            out.write('0'.code)
         } else {
             writeInt(begin)
             if (length > 1) {
-                out.write(','.toInt())
+                out.write(','.code)
                 writeInt(length)
             }
         }
@@ -183,7 +183,7 @@ internal class WriteSpaceAwareDiffFormatter(
         var i = 0
         val len = str.length
         while (i < len) {
-            out.write(str[i].toInt())
+            out.write(str[i].code)
             i++
         }
     }
@@ -195,8 +195,8 @@ internal class WriteSpaceAwareDiffFormatter(
         lines: IntList,
         showWhitespace: Boolean
     ) {
-        out.write('\n'.toInt())
-        out.write(prefix.toInt())
+        out.write('\n'.code)
+        out.write(prefix.code)
         if (!showWhitespace) {
             a.writeLine(out, lineA)
             return
@@ -206,16 +206,16 @@ internal class WriteSpaceAwareDiffFormatter(
         val end = lines[lineA + 2]
         while (i < end) {
             when (val b = bytes[i]) {
-                ' '.toByte() -> {
+                ' '.code.toByte() -> {
                     out.write(middleDot)
                 }
-                '\t'.toByte() -> {
+                '\t'.code.toByte() -> {
                     out.write(tab)
                 }
-                '\r'.toByte() -> {
+                '\r'.code.toByte() -> {
                     out.write(cr)
                 }
-                '\n'.toByte() -> {
+                '\n'.code.toByte() -> {
                     out.write(lf)
                 }
                 else -> {

--- a/lib/src/main/kotlin/com/github/autostyle/ConvergenceAnalyzer.kt
+++ b/lib/src/main/kotlin/com/github/autostyle/ConvergenceAnalyzer.kt
@@ -27,7 +27,7 @@ sealed class ConvergenceResult(open val formatted: String) {
     }
 
     data class Convergence(val cycle: List<String>) : ConvergenceResult(cycle.last())
-    data class Cycle(val cycle: List<String>) : ConvergenceResult(cycle.minWith(listComparator)!!)
+    data class Cycle(val cycle: List<String>) : ConvergenceResult(cycle.minWithOrNull(listComparator)!!)
     data class Divergence(val cycle: List<String>) : ConvergenceResult("") {
         override val formatted: String
             get() = throw IllegalStateException("The formatting result diverges")

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -13,9 +13,9 @@ output = [
 -->
 [![Gradle plugin](https://img.shields.io/badge/plugins.gradle.org-com.github.autostyle-blue.svg)](https://plugins.gradle.org/plugin/com.github.autostyle)
 [![Maven central](https://img.shields.io/badge/mavencentral-com.github.autostyle.gradle%3Aautostyle-blue.svg)](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.github.autostyle%22%20AND%20a%3A%22autostyle-plugin-gradle%22)
-[![Javadoc](https://img.shields.io/badge/javadoc-3.1-blue.svg)](https://autostyle.github.io/autostyle/javadoc/autostyle-plugin-gradle/3.1/)
+[![Javadoc](https://img.shields.io/badge/javadoc-4.0-blue.svg)](https://autostyle.github.io/autostyle/javadoc/autostyle-plugin-gradle/4.0/)
 
-[![Changelog](https://img.shields.io/badge/changelog-3.1-brightgreen.svg)](CHANGES.md)
+[![Changelog](https://img.shields.io/badge/changelog-4.0-brightgreen.svg)](CHANGES.md)
 [![Travis CI](https://travis-ci.org/autostyle/autostyle.svg?branch=master)](https://travis-ci.org/autostyle/autostyle)
 [![Live chat](https://img.shields.io/badge/gitter-chat-brightgreen.svg)](https://gitter.im/autostyle/autostyle)
 <!---freshmark /shields -->
@@ -79,7 +79,7 @@ autostyle {
 }
 ```
 
-Autostyle can check and apply formatting to any plain-text file, using simple rules ([javadoc](https://autostyle.github.io/autostyle/javadoc/autostyle-plugin-gradle/3.1/com/github/autostyle/gradle/FormatExtension.html)) like those above.  It also supports more powerful formatters:
+Autostyle can check and apply formatting to any plain-text file, using simple rules ([javadoc](https://autostyle.github.io/autostyle/javadoc/autostyle-plugin-gradle/4.0/com/github/autostyle/gradle/FormatExtension.html)) like those above.  It also supports more powerful formatters:
 
 * Eclipse's [CDT](#eclipse-cdt) C/C++ code formatter
 * Eclipse's java code formatter (including style and import ordering)
@@ -678,7 +678,7 @@ autostyle {
 }
 ```
 
-If you use `custom` or `customLazy`, you might want to take a look at [this javadoc](https://autostyle.github.io/autostyle/javadoc/autostyle-plugin-gradle/3.1/com/github/autostyle/gradle/FormatExtension.html#bumpThisNumberIfACustomStepChanges-int-) for a big performance win.
+If you use `custom` or `customLazy`, you might want to take a look at [this javadoc](https://autostyle.github.io/autostyle/javadoc/autostyle-plugin-gradle/4.0/com/github/autostyle/gradle/FormatExtension.html#bumpThisNumberIfACustomStepChanges-int-) for a big performance win.
 
 See [`JavaExtension.java`](src/main/java/com/github/autostyle/gradle/JavaExtension.java) if you'd like to see how a language-specific set of custom rules is implemented.  We'd love PR's which add support for other languages.
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -68,7 +68,7 @@ buildscript {
     if (property("skipAutostyle")?.ifBlank { "true" }?.toBoolean() == true) {
         // Skip
     } else if (property("autostyleSelf")?.ifBlank { "true" }?.toBoolean() == true) {
-        val ver = property("autostyle.version") + "-SNAPSHOT"
+        val ver = "current".v() + "-SNAPSHOT"
 
         repositories {
             gradlePluginPortal()

--- a/testlib/src/main/kotlin/com/github/autostyle/TestProvisioner.kt
+++ b/testlib/src/main/kotlin/com/github/autostyle/TestProvisioner.kt
@@ -22,6 +22,8 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ResolveException
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.attributes.Bundling
+import org.gradle.api.attributes.Usage
+import org.gradle.api.attributes.java.TargetJvmEnvironment
 import org.gradle.testfixtures.ProjectBuilder
 import java.io.File
 import java.nio.file.Files
@@ -62,6 +64,20 @@ object TestProvisioner {
                     it.attribute(
                         Bundling.BUNDLING_ATTRIBUTE,
                         project.objects.named(Bundling::class.java, Bundling.EXTERNAL)
+                    )
+                    // google-java-format 1.28 pulls guava, which publishes both jre/android
+                    // and api/runtime variants. Bundling alone is ambiguous, so pin the
+                    // runtime classpath on a standard JVM to select guava's jreRuntimeElements.
+                    it.attribute(
+                        Usage.USAGE_ATTRIBUTE,
+                        project.objects.named(Usage::class.java, Usage.JAVA_RUNTIME)
+                    )
+                    it.attribute(
+                        TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
+                        project.objects.named(
+                            TargetJvmEnvironment::class.java,
+                            TargetJvmEnvironment.STANDARD_JVM
+                        )
                     )
                 }
             }.resolve()


### PR DESCRIPTION
## Why

`master` CI is red, and every open dependency-update PR inherits the same red
checks. None of the failures come from the bumps themselves; they are
pre-existing breakage on `master`:

- `Linux (JDK 17)` fails in its test tasks.
- `Self-check, Linux (JDK 17)` fails to compile its scripts.

GitHub's `master` is still at `024437f7`. This branch also carries two local
commits that were never pushed (`0021bcc6`, `c349d038`), including the
`build.gradle.kts` import-order fix the `Linux` job needs.

## What

**Self-check job** (`ac0f63bd`):
- Resolve the self-check plugin jars from `current.version` instead of the
  undefined `autostyle.version`. The empty classpath caused "Unresolved
  reference: autostyle".
- Add `--add-exports` to the daemon so google-java-format 1.28 can run inside
  the build JVM on JDK 16 and later.

**Linux / test job** (`c2ffc808`):
- Declare `junit-platform-launcher` so the launcher tracks junit-bom 5.13. This
  fixes "OutputDirectoryProvider not available".
- Add `--add-exports` to the test workers for google-java-format 1.28.
- Disambiguate guava's variants in `TestProvisioner` by requesting a
  standard-JVM runtime classpath, so google-java-format 1.28's transitive guava
  resolves.

The two regress jobs (`Apache JMeter`, `vlsi-release-plugins`) stay red and are
out of scope: they clone external repositories at HEAD and fail on those
projects' dependency verification and Gradle 9 compilation, independent of any
bump or of this change.

## How to verify

Under JDK 17 (matches CI):

```
./gradlew --no-parallel --no-daemon build -x npmTest -x autostyleFreshmarkCheck
./gradlew --no-parallel --no-daemon jar
./gradlew --no-parallel --no-daemon -PautostyleSelf autostyleCheck
```

Both succeed on this branch and fail on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
