### PR TITLE
fix(ci): disable dependency verification in the JMeter regression check

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -27,14 +27,17 @@ jobs:
         run: |
           git clone --depth 100 https://github.com/apache/jmeter.git ../jmeter
           git rev-parse HEAD
+      # JMeter enables Gradle dependency verification, but its verification-metadata.xml
+      # does not cover Autostyle's own build dependencies, so turn verification off for
+      # the regression check.
       - name: 'autostyleCheck'
         working-directory: ../jmeter
         run: |
-          ./gradlew -no-parallel --no-daemon -PchecksumIgnore -PlocalAutostyle autostyleCheck
+          ./gradlew -no-parallel --no-daemon -PchecksumIgnore -PlocalAutostyle --dependency-verification=off autostyleCheck
       - name: 'autostyleApply'
         working-directory: ../jmeter
         run: |
-          ./gradlew -no-parallel --no-daemon -PchecksumIgnore -PlocalAutostyle autostyleApply
+          ./gradlew -no-parallel --no-daemon -PchecksumIgnore -PlocalAutostyle --dependency-verification=off autostyleApply
 
   linux-vrp:
     name: 'vlsi-release-plugins (JDK 17, Linux)'


### PR DESCRIPTION
## Why

The `Apache JMeter (JDK 17, MacOS)` regression job has been red on every PR. JMeter enables Gradle dependency verification, and its `verification-metadata.xml` does not list Autostyle's own build dependencies (nmcp and its transitives). Because the job pulls Autostyle in with `-PlocalAutostyle`, verification fails on `:autostyle:buildSrc:compileClasspath` before the formatter runs.

## What

Run the JMeter `autostyleCheck` / `autostyleApply` steps with `--dependency-verification=off`. The job exercises the formatter against JMeter's sources, not JMeter's supply chain, so verification adds no value here.

## How to verify

The `Apache JMeter (JDK 17, MacOS)` job on this PR should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
