### PR TITLE
feat!: require Java 17 and bump JGit to 7.7.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Version 5.0
+* Require Java 17 to run Autostyle (the Java target moves from 8 to 17)
+* Bump org.eclipse.jgit to 7.7.0; jgit 7.x requires Java 17
+
 ### Version 4.0
 * Drop Eclipse-based formatters
 * Bump Gradle to 8.5

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
         // runtime means "the dependency is only for runtime, not for compilation"
         // In other words, marking dependency as "runtime" would avoid accidental
         // dependency on it during compilation
-        api("org.eclipse.jgit:org.eclipse.jgit:5.13.3.202401111512-r")
+        api("org.eclipse.jgit:org.eclipse.jgit:7.7.0.202606012155-r")
         api("com.googlecode.concurrent-trees:concurrent-trees:2.6.1")
         api("org.slf4j:slf4j-api:1.7.36")
         api("org.slf4j:slf4j-log4j12:1.7.36")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,9 +99,9 @@ allprojects {
             @Suppress("DEPRECATION")
             apiVersion = KotlinVersion.KOTLIN_1_8
             languageVersion = apiVersion
-            jvmTarget = JvmTarget.JVM_1_8
+            jvmTarget = JvmTarget.JVM_17
             freeCompilerArgs.add("-Xjvm-default=all")
-            freeCompilerArgs.add("-Xjdk-release=1.8")
+            freeCompilerArgs.add("-Xjdk-release=17")
         }
     }
 
@@ -128,7 +128,7 @@ allprojects {
         tasks {
             withType<JavaCompile>().configureEach {
                 options.encoding = "UTF-8"
-                options.release.set(8)
+                options.release.set(17)
             }
 
             withType<Jar>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 import com.github.vlsi.gradle.properties.dsl.props
+import java.time.Duration
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-import java.time.Duration
 
 plugins {
     id("com.github.autostyle")

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ description=Autostyle - fix code style automatically
 
 group=com.github.autostyle
 released.version=4.0
-current.version=4.0.2
+current.version=5.0

--- a/lib-extra/src/main/kotlin/com/github/autostyle/extra/integration/WriteSpaceAwareDiffFormatter.kt
+++ b/lib-extra/src/main/kotlin/com/github/autostyle/extra/integration/WriteSpaceAwareDiffFormatter.kt
@@ -49,10 +49,10 @@ internal class WriteSpaceAwareDiffFormatter(
         private val CR_UTF8 = CR.toByteArray(StandardCharsets.UTF_8)
         private val LF_UTF8 = LF.toByteArray(StandardCharsets.UTF_8)
         private val TAB_UTF8 = TAB.toByteArray(StandardCharsets.UTF_8)
-        private val SPACE_SIMPLE = byteArrayOf(' '.toByte())
-        private val CR_SIMPLE = byteArrayOf('\\'.toByte(), 'r'.toByte())
-        private val LF_SIMPLE = byteArrayOf('\\'.toByte(), 'n'.toByte())
-        private val TAB_SIMPLE = byteArrayOf('\\'.toByte(), 't'.toByte())
+        private val SPACE_SIMPLE = byteArrayOf(' '.code.toByte())
+        private val CR_SIMPLE = byteArrayOf('\\'.code.toByte(), 'r'.code.toByte())
+        private val LF_SIMPLE = byteArrayOf('\\'.code.toByte(), 'n'.code.toByte())
+        private val TAB_SIMPLE = byteArrayOf('\\'.code.toByte(), 't'.code.toByte())
         private val isWindows = "win" in System.getProperty("os.name").toLowerCase()
         private fun replacementFor(
             charsetEncoder: CharsetEncoder,
@@ -96,7 +96,7 @@ internal class WriteSpaceAwareDiffFormatter(
             if (firstLine) {
                 firstLine = false
             } else {
-                out.write('\n'.toInt())
+                out.write('\n'.code)
             }
             header(lineA, endA, lineB, endB)
             var showWhitespace = edit.type == Edit.Type.REPLACE
@@ -153,26 +153,26 @@ internal class WriteSpaceAwareDiffFormatter(
     }
 
     private fun header(lineA: Int, endA: Int, lineB: Int, endB: Int) {
-        out.write('@'.toInt())
-        out.write('@'.toInt())
+        out.write('@'.code)
+        out.write('@'.code)
         range('-', lineA + 1, endA - lineA)
         range('+', lineB + 1, endB - lineB)
-        out.write(' '.toInt())
-        out.write('@'.toInt())
-        out.write('@'.toInt())
+        out.write(' '.code)
+        out.write('@'.code)
+        out.write('@'.code)
     }
 
     private fun range(prefix: Char, begin: Int, length: Int) {
-        out.write(' '.toInt())
-        out.write(prefix.toInt())
+        out.write(' '.code)
+        out.write(prefix.code)
         if (length == 0) {
             writeInt(begin - 1)
-            out.write(','.toInt())
-            out.write('0'.toInt())
+            out.write(','.code)
+            out.write('0'.code)
         } else {
             writeInt(begin)
             if (length > 1) {
-                out.write(','.toInt())
+                out.write(','.code)
                 writeInt(length)
             }
         }
@@ -183,7 +183,7 @@ internal class WriteSpaceAwareDiffFormatter(
         var i = 0
         val len = str.length
         while (i < len) {
-            out.write(str[i].toInt())
+            out.write(str[i].code)
             i++
         }
     }
@@ -195,8 +195,8 @@ internal class WriteSpaceAwareDiffFormatter(
         lines: IntList,
         showWhitespace: Boolean
     ) {
-        out.write('\n'.toInt())
-        out.write(prefix.toInt())
+        out.write('\n'.code)
+        out.write(prefix.code)
         if (!showWhitespace) {
             a.writeLine(out, lineA)
             return
@@ -206,16 +206,16 @@ internal class WriteSpaceAwareDiffFormatter(
         val end = lines[lineA + 2]
         while (i < end) {
             when (val b = bytes[i]) {
-                ' '.toByte() -> {
+                ' '.code.toByte() -> {
                     out.write(middleDot)
                 }
-                '\t'.toByte() -> {
+                '\t'.code.toByte() -> {
                     out.write(tab)
                 }
-                '\r'.toByte() -> {
+                '\r'.code.toByte() -> {
                     out.write(cr)
                 }
-                '\n'.toByte() -> {
+                '\n'.code.toByte() -> {
                     out.write(lf)
                 }
                 else -> {

--- a/lib/src/main/kotlin/com/github/autostyle/ConvergenceAnalyzer.kt
+++ b/lib/src/main/kotlin/com/github/autostyle/ConvergenceAnalyzer.kt
@@ -27,7 +27,7 @@ sealed class ConvergenceResult(open val formatted: String) {
     }
 
     data class Convergence(val cycle: List<String>) : ConvergenceResult(cycle.last())
-    data class Cycle(val cycle: List<String>) : ConvergenceResult(cycle.minWith(listComparator)!!)
+    data class Cycle(val cycle: List<String>) : ConvergenceResult(cycle.minWithOrNull(listComparator)!!)
     data class Divergence(val cycle: List<String>) : ConvergenceResult("") {
         override val formatted: String
             get() = throw IllegalStateException("The formatting result diverges")

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -13,9 +13,9 @@ output = [
 -->
 [![Gradle plugin](https://img.shields.io/badge/plugins.gradle.org-com.github.autostyle-blue.svg)](https://plugins.gradle.org/plugin/com.github.autostyle)
 [![Maven central](https://img.shields.io/badge/mavencentral-com.github.autostyle.gradle%3Aautostyle-blue.svg)](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.github.autostyle%22%20AND%20a%3A%22autostyle-plugin-gradle%22)
-[![Javadoc](https://img.shields.io/badge/javadoc-3.1-blue.svg)](https://autostyle.github.io/autostyle/javadoc/autostyle-plugin-gradle/3.1/)
+[![Javadoc](https://img.shields.io/badge/javadoc-4.0-blue.svg)](https://autostyle.github.io/autostyle/javadoc/autostyle-plugin-gradle/4.0/)
 
-[![Changelog](https://img.shields.io/badge/changelog-3.1-brightgreen.svg)](CHANGES.md)
+[![Changelog](https://img.shields.io/badge/changelog-4.0-brightgreen.svg)](CHANGES.md)
 [![Travis CI](https://travis-ci.org/autostyle/autostyle.svg?branch=master)](https://travis-ci.org/autostyle/autostyle)
 [![Live chat](https://img.shields.io/badge/gitter-chat-brightgreen.svg)](https://gitter.im/autostyle/autostyle)
 <!---freshmark /shields -->
@@ -79,7 +79,7 @@ autostyle {
 }
 ```
 
-Autostyle can check and apply formatting to any plain-text file, using simple rules ([javadoc](https://autostyle.github.io/autostyle/javadoc/autostyle-plugin-gradle/3.1/com/github/autostyle/gradle/FormatExtension.html)) like those above.  It also supports more powerful formatters:
+Autostyle can check and apply formatting to any plain-text file, using simple rules ([javadoc](https://autostyle.github.io/autostyle/javadoc/autostyle-plugin-gradle/4.0/com/github/autostyle/gradle/FormatExtension.html)) like those above.  It also supports more powerful formatters:
 
 * Eclipse's [CDT](#eclipse-cdt) C/C++ code formatter
 * Eclipse's java code formatter (including style and import ordering)
@@ -678,7 +678,7 @@ autostyle {
 }
 ```
 
-If you use `custom` or `customLazy`, you might want to take a look at [this javadoc](https://autostyle.github.io/autostyle/javadoc/autostyle-plugin-gradle/3.1/com/github/autostyle/gradle/FormatExtension.html#bumpThisNumberIfACustomStepChanges-int-) for a big performance win.
+If you use `custom` or `customLazy`, you might want to take a look at [this javadoc](https://autostyle.github.io/autostyle/javadoc/autostyle-plugin-gradle/4.0/com/github/autostyle/gradle/FormatExtension.html#bumpThisNumberIfACustomStepChanges-int-) for a big performance win.
 
 See [`JavaExtension.java`](src/main/java/com/github/autostyle/gradle/JavaExtension.java) if you'd like to see how a language-specific set of custom rules is implemented.  We'd love PR's which add support for other languages.
 

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -32,6 +32,9 @@ Autostyle is a general-purpose formatting plugin.  It is completely à la carte,
 |-----------|---------|--------------|-------------|---------------|
 | 3.2       | 5.6-7.0 | 8-16         | 8           | 1.3           |
 | 4.0       | 7.0+    | 8+           | 8           | 1.4           |
+| 5.0       | 7.3+    | 17+          | 17          | 1.8           |
+
+Autostyle 5.0 requires Java 17. It bundles JGit 7.x, which needs Java 17, so run Gradle on a Java 17 (or newer) JVM.
 
 To people who use your build, it looks like this:
 

--- a/renovate.json
+++ b/renovate.json
@@ -15,8 +15,7 @@
     {
       "matchPackagePrefixes": ["org.eclipse.jgit"],
       "groupName": "org.eclipse.jgit",
-      "description": "TODO: jgit 6.0 requires Java 11",
-      "allowedVersions": "< 6.0"
+      "description": "jgit 7.x requires Java 17, which Autostyle 5.0 already targets"
     },
     {
       "matchPackagePrefixes": ["org.jdrupes.mdoclet"],

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -79,7 +79,7 @@ buildscript {
                 "lib/build/libs/autostyle-lib-$ver.jar",
                 "lib-extra/build/libs/autostyle-lib-extra-$ver.jar"))
             // needed by GitAttributesLineEndings
-            classpath("org.eclipse.jgit:org.eclipse.jgit:5.13.3.202401111512-r")
+            classpath("org.eclipse.jgit:org.eclipse.jgit:7.7.0.202606012155-r")
             classpath("com.googlecode.concurrent-trees:concurrent-trees:2.6.1")
         }
     } else {


### PR DESCRIPTION
## Why

Projects that depend on Autostyle pull in a transitive `org.eclipse.jgit:org.eclipse.jgit 5.13` through `autostyle-plugin-gradle`. JGit 5.13 is the last Java 8 line and is effectively frozen, so tracking newer JGit needs a higher minimum Java. Autostyle was still capped at Java 8, which blocked the upgrade.

## What

Autostyle 5.0 raises the minimum Java runtime from 8 to 17 and bumps JGit to the latest release, 7.7.0.

- `current.version` → 5.0
- Java target/bytecode 8 → 17 (`options.release`, Kotlin `jvmTarget`, and `-Xjdk-release`)
- `org.eclipse.jgit` 5.13.3 → 7.7.0.202606012155-r (BOM and the `autostyleSelf` buildscript classpath)
- Renovate: drop the `< 6.0` cap on JGit now that Java 17 is the baseline
- Docs: a compatibility-matrix row and a `Version 5.0` changelog entry

JGit 7.7.0 is a clean drop-in. It ships `Bundle-RequiredExecutionEnvironment: JavaSE-17` and Java 17 bytecode, and every API Autostyle uses (`RawText`, `RawTextComparator`, `HistogramDiff`, `Edit`/`EditList`, `attributes.*`, `lib.Config`, `FileRepositoryBuilder`, `SystemReader`) is unchanged in 7.x, so no source changes were needed.

## How to verify

- `./gradlew :autostyle-lib-extra:compileJava :autostyle-lib-extra:compileKotlin` compiles against JGit 7.7.0 with no errors. The 8 deprecation notes are pre-existing internal-API warnings (`FileSignature.signAsList/signAsSet`, `Class.newInstance`), unrelated to JGit.
- A standalone runtime check of the diff path (`RawText` + `HistogramDiff` + `RawTextComparator` + `DiffFormatter`) succeeds on a Java 17/21 JVM.
- Note: `:autostyle-plugin-gradle:test` already fails on `master` from an unrelated JUnit Platform launcher/engine version mismatch; this PR neither causes nor fixes it.

## Breaking change

Autostyle 5.0 requires Java 17. Builds on older JVMs must stay on Autostyle 4.x.
