### PR TITLE
ci: add aggregating "Tests" check for branch protection

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,3 +46,20 @@ jobs:
         run: |
           ./gradlew --no-parallel --no-daemon jar
           ./gradlew --no-parallel --no-daemon -PautostyleSelf autostyleCheck
+
+  # Aggregating job: branch protection requires only this check, so the matrix
+  # jobs above can change their JDK or OS without touching the required checks.
+  tests:
+    name: 'Tests'
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs:
+      - linux
+      - linux-self
+    steps:
+      - name: 'Fail unless every required job succeeded'
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: |
+          echo 'A required job did not succeed:'
+          echo '${{ toJSON(needs) }}'
+          exit 1


### PR DESCRIPTION
Add a `Tests` job that needs the matrix jobs (`linux`, `linux-self`) and fails unless every one succeeds.

Branch protection can then require this single `Tests` check instead of each matrix job by name, so changing a job (for example bumping the JDK version, which renames `Linux (JDK 17)`) no longer means editing the list of required checks.

Follow-up to #74, whose own CI change was dropped when that PR was squashed from a stale head.