### PR TITLE
fix: expand Ant-style glob string targets

### DIFF
--- a/plugin-gradle/src/main/kotlin/com/github/autostyle/gradle/BaseFormatExtension.kt
+++ b/plugin-gradle/src/main/kotlin/com/github/autostyle/gradle/BaseFormatExtension.kt
@@ -221,10 +221,17 @@ open class BaseFormatExtension @Inject constructor(
                             project.files(it).asFileTree
                         }
                     is String ->
-                        if (File(it).isDirectory) {
-                            project.fileTree(it)
-                        } else {
-                            project.files(it).asFileTree
+                        when {
+                            File(it).isDirectory -> project.fileTree(it)
+                            it.any { c -> c == '*' || c == '?' } -> {
+                                // Ant-style glob (e.g. "**/*.md"): resolve as an include pattern
+                                // relative to the project directory. Project.files() does not
+                                // expand globs, so a glob target would otherwise silently match
+                                // nothing.
+                                val pattern = it
+                                project.fileTree(project.projectDir) { include(pattern) }
+                            }
+                            else -> project.files(it).asFileTree
                         }
                     else -> project.fileTree(it)
                 }.matching(filter)

--- a/plugin-gradle/src/test/java/com/github/autostyle/gradle/TargetGlobTest.java
+++ b/plugin-gradle/src/test/java/com/github/autostyle/gradle/TargetGlobTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Vladimir Sitnikov <sitnikov.vladimir@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.autostyle.gradle;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class TargetGlobTest extends GradleIntegrationTest {
+  /**
+   * A String target such as {@code target("**&#47;*.md")} must be treated as an Ant-style
+   * include glob relative to the project directory, matching files in the root and in nested
+   * directories. Before the fix, the String was passed to {@code Project.files()}, which does
+   * not expand globs, so the target silently matched nothing and no file was formatted.
+   *
+   * <p>The assertions read the whole file (including the trailing newline) rather than using
+   * {@code hasContent}, which compares line by line and would ignore a missing final newline.
+   */
+  @Test
+  public void stringGlobMatchesFilesRecursively() throws IOException {
+    setFile("build.gradle").toLines(
+        "plugins {",
+        "    id 'com.github.autostyle'",
+        "}",
+        "autostyle {",
+        "    format('misc') {",
+        "        target('**/*.md')",
+        "        endWithNewline()",
+        "    }",
+        "}");
+    // Files without a trailing newline, in the root and in nested directories.
+    setFile("README.md").toContent("root");
+    setFile("docs/a.md").toContent("a");
+    setFile("docs/nested/b.md").toContent("b");
+    // A file that does not match the glob must be left untouched (no trailing newline added).
+    setFile("docs/keep.txt").toContent("keep");
+
+    gradleRunner().withArguments("autostyleApply").build();
+
+    assertFile("README.md").matches(it -> it.isEqualTo("root\n"));
+    assertFile("docs/a.md").matches(it -> it.isEqualTo("a\n"));
+    assertFile("docs/nested/b.md").matches(it -> it.isEqualTo("b\n"));
+    assertFile("docs/keep.txt").matches(it -> it.isEqualTo("keep"));
+  }
+}


### PR DESCRIPTION
## Why

A format configured with a String glob target matched nothing: `target("**/*.md")` and similar silently formatted zero files. `BaseFormatExtension.configureTask` resolved a String target through `Project.files()`, which does not expand Ant-style globs, so the resulting file tree was empty. The glob was accepted without error, so the misconfiguration stayed invisible.

## What

Treat a String target that contains glob metacharacters (`*` or `?`) as an Ant-style include pattern relative to the project directory. A String that names an existing directory still resolves to a `fileTree`, and a plain-path String still goes through `Project.files()`, so existing configurations are unaffected.

## How to verify

`TargetGlobTest` covers a `target("**/*.md")` glob that matches files in the project root and in nested directories, and confirms a non-matching file is left untouched:

```
./gradlew :autostyle-plugin-gradle:test --tests com.github.autostyle.gradle.TargetGlobTest
```

The test asserts exact file bytes rather than using `hasContent`, which compares line by line and would ignore a missing final newline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
